### PR TITLE
Improve naming clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This is the app you get when you run `streamlit hello`, extracted as its own app.
 
-Edit [Hello.py](./Hello.py) to customize this app to your heart's desire. ❤️
+Edit [article_relevance_app.py](./article_relevance_app.py) to customize this app to your heart's desire. ❤️
 
 Check it out on [Streamlit Community Cloud](https://st-hello-app.streamlit.app/)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5,12 +5,16 @@ import types
 # Ensure repository root is on the path
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-# Provide a minimal streamlit stub so Hello can be imported without dependencies.
-sys.modules['streamlit'] = types.SimpleNamespace()
-sys.modules['openai'] = types.SimpleNamespace(OpenAI=lambda: None)
-sys.modules['presets'] = types.SimpleNamespace(preset_json='', preset_url='')
+# Provide minimal stubs so the app can be imported without dependencies.
+sys.modules["streamlit"] = types.SimpleNamespace()
+sys.modules["openai"] = types.SimpleNamespace(OpenAI=lambda: None)
+sys.modules["presets"] = types.SimpleNamespace(preset_json="", preset_url="")
+sys.modules["dotenv"] = types.SimpleNamespace(load_dotenv=lambda: None)
+sys.modules["bs4"] = types.SimpleNamespace(BeautifulSoup=lambda *a, **k: None)
+sys.modules["pandas"] = types.SimpleNamespace(DataFrame=lambda *a, **k: None)
+sys.modules["requests"] = types.SimpleNamespace(get=lambda *a, **k: None)
 
-import Hello
+import article_relevance_app as app
 
 class MockChunk:
     def __init__(self, content):
@@ -23,8 +27,8 @@ def test_get_relevance_scores_streaming_yields_each_chunk(monkeypatch):
             completions=types.SimpleNamespace(create=lambda *args, **kwargs: iter(chunks))
         )
     )
-    monkeypatch.setattr(Hello, 'client', dummy_client)
+    monkeypatch.setattr(app, 'openai_client', dummy_client)
 
-    result = list(Hello.get_relevance_scores_streaming('text', '{}'))
+    result = list(app.stream_relevance_scores('text', '{}'))
     assert result == ['a', 'b', '', 'c']
 


### PR DESCRIPTION
## Summary
- rename `Hello.py` to `article_relevance_app.py`
- rename helper functions and variables to clearer names
- update README and tests for new module name
- provide additional module stubs for tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68497d2c79ac833386f996b3c8beb9db